### PR TITLE
Add-resource-detail-tab-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,35 @@ CloudBolt applications interpret this field to determine where to render applets
 {
   "cui": {
     "pageName": ["target1", "target2"],
+    "anotherPageName": ["all"],
     "all": ["target3"]
   }
 }
 ```
 
-In this example, the page called `pageName` will have the applet rendered in the `target1` and `target2` targets. All pages will have the applet rendered in the `target3` target if the page has a `target3`.
+In this example, the page called `pageName` will render in the `target1` and `target2` targets. the page called `anotherPageName` will render the applet in all targets. All pages will have the applet rendered in the `target3` target if the page has a `target3`. This is especially useful for cross-app additions, like footers or navigation items added to every page.
 
-There will be a documented list of targets for the CUI in official documentation. However, all targets are discoverable by creating a simple applet that runs console.logs out the `page` and `area` props of the `TheApplet` component and setting the `met_targets` to `{"cui": {"all": ["all"]}}`.
+There will be a list of targets for the CUI in official documentation. However, all targets are discoverable by creating a simple applet that runs console.logs out the `page` and `area` props of the `TheApplet` component and setting the `met_targets` to `{"cui": {"all": ["all"]}}`.
+
+One exception to this target discoverability is represented by this example:
+
+```json
+{
+  "cui": {
+    "resourceDetailsTabs": [
+      {
+        "resourceTypes": ["service"],
+        "label": "Additional Info"
+      }
+    ]
+  }
+}
+```
+
+`resourceDetailsTabs` is a special target that will render the applet as a tab on the resource details page. It should be an array of a single configuration object with two optional fields:
+
+- `resourceTypes` is an array of resource type names that the tab should be rendered for (defaults to `['all']`).
+- `label` is the label that will be displayed on the tab (defaults to the applet's `met_label`).
 
 ## Repo Contents
 

--- a/package.json
+++ b/package.json
@@ -13,14 +13,22 @@
     "met_required_ui_extensions": [
       {
         "name": "cui",
-        "minimum_version": "2023.1.0",
+        "minimum_version": "2023.3.58",
         "maximum_version": ""
       }
     ],
     "met_targets": {
       "cui": {
+        "resourceDetailsTabs": [
+          {
+            "resourceTypes": [
+              "service"
+            ],
+            "label": "Additional Info"
+          }
+        ],
         "catalog": [
-          "prePageContent"
+          "headerLoggedIn"
         ],
         "all": [
           "preNavItems"

--- a/src/ACounter.vue
+++ b/src/ACounter.vue
@@ -1,0 +1,29 @@
+<template>
+  <!-- 
+    VBtn comes from Vuetify: https://vuetifyjs.com/en/components/buttons/ 
+  
+    The `@click`s are a examples of how you bind js functions to events on elements.
+    See more: https://vuejs.org/guide/essentials/event-handling.html
+  -->
+  <VBtn @click="increment">Increment</VBtn>
+  <VBtn @click="decrement">Decrement</VBtn>
+  <p>The count is {{ count }}</p>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+/**
+ * Each Vue component has its own state. If you put two copies of this component on
+ * the same page, they will have independent counts.
+ */
+const count = ref(0);
+
+const increment = () => {
+  count.value++;
+};
+
+const decrement = () => {
+  count.value--;
+};
+</script>

--- a/src/MainView.vue
+++ b/src/MainView.vue
@@ -1,0 +1,119 @@
+<template>
+  <h2>CB Applet Hello World Example</h2>
+  <p>
+    This is a simple example of a CloudBolt Applet. It's a Vue component that is
+    loaded into the CloudBolt UI and can be used to add functionality to
+    CloudBolt.
+
+    <!-- 
+        Use double-curly-braces to render a variable from the `script` section in the template. 
+        You can use any valid javascript expression in the double-curly-braces.
+       -->
+    {{ message + "!" }}
+  </p>
+
+  <!-- 
+      If you prepend an attribute with `:` (short for `v-bind:`), vue will treat the attribute's
+      value as javascript. This loads the imageUrl as imported in the below `script` section.
+    -->
+  <img :src="imageUrl" alt="CloudBolt logo" />
+  <p>Time: {{ time }}</p>
+
+  <!-- 
+      Prepend props like "api" with `:` to bind them to child components. `:` is short for `v-bind:`.
+     -->
+  <NestedComponent :api="api" />
+  <ACounter />
+</template>
+
+<script setup>
+import camelCase from "camelCase";
+import {
+  computed,
+  defineProps,
+  onBeforeMount,
+  onBeforeUnmount,
+  onBeforeUpdate,
+  onMounted,
+  onUnmounted,
+  onUpdated,
+  ref,
+} from "vue";
+import NestedComponent from "./NestedComponent.vue";
+import imageUrl from "./assets/cb_logo_255x60.png";
+
+/**
+ * @typedef {object} Props
+ * @property {ReturnType<import("@cloudbolt/js-sdk").createApi>} Props.api - The authenticated API instance
+ */
+
+/** @type {Props} */
+const props = defineProps({
+  api: {
+    type: Object,
+    required: true,
+  },
+});
+
+/**
+ * You can use any third-party library you'd like to install via npm
+ * Any libraries you import and use get bundled into the applet.
+ */
+const greeting = camelCase("hello-world");
+
+// Everything defined in <script setup> (like this normal variable) is available in the template above.
+const message = `The string "${greeting}" is processed by an installed npm package`;
+
+/**
+ * The only problem with the above code is that it's not reactive. If the greeting were to change
+ * somehow, (for example, if it was passed in as a prop instead of hard-coded), the console.log
+ * wouldn't run again or understand that props.page has changed since the applet first loaded.
+ *
+ * Vue provides a few ways to make values reactive. The two most common are:
+ *  - `ref` - a reactive value that can be changed.
+ *     @see https://vuejs.org/guide/essentials/reactivity-fundamentals.html
+ *  - `computed` - a reactive value that is derived from other reactive values.
+ *     @see https://vuejs.org/guide/essentials/computed.html
+ *
+ * The vue documentation is excellent and worth reading. Let's explore this with a simple example.
+ */
+
+// Create a reactive value (a ref), initialized to the current date and time
+const currentDateTime = ref(new Date());
+// Create a computed value by defining a function that returns the current time as a string
+const time = computed(() => currentDateTime.value.toLocaleTimeString());
+// We  reference `time` in the template above. It will automatically update when currentDateTime changes.
+
+// Let's update the time every second.
+function updateCurrentDateTime() {
+  currentDateTime.value = new Date();
+}
+const timeUpdateInternal = setInterval(updateCurrentDateTime, 1000);
+// As the time changes, the template react to the changed `computed` (based on the `ref`) and update.
+
+/**
+ * Vue also provides lifecycle hooks to run code at different points in the component's lifecycle.
+ * These can be used to load data, set up event listeners, clean up, etc.
+ * See https://vuejs.org/guide/essentials/lifecycle.html#registering-lifecycle-hooks
+ */
+console.log("I run on setup");
+onBeforeMount(() => console.log("I run before the component is mounted"));
+onMounted(() => console.log("I run after the component is mounted"));
+onBeforeUpdate(() => console.log("I run before the component is updated"));
+onUpdated(() => console.log("I run after the component is updated"));
+onBeforeUnmount(() => console.log("I run before the component is unmounted"));
+onUnmounted(() => console.log("I run after the component is unmounted"));
+
+// Let's use one of these to clean up the interval we created earlier when we unmount the component.
+onUnmounted(() => clearInterval(timeUpdateInternal));
+</script>
+
+<!-- 
+  The `style` is where you write your CSS. "scoped" styles only apply to this component - not even 
+  child components will be affected. This is a great way to make sure your styles don't leak out.
+-->
+<style scoped>
+h2 {
+  color: #1e88e5;
+}
+</style>

--- a/src/NavbarView.vue
+++ b/src/NavbarView.vue
@@ -1,0 +1,6 @@
+<!-- Vue components don't have to be complicated. They can just be a bit of powered-up HTML. -->
+
+<template>
+  <!-- Vue has special handling for `style`, allowing you to feed it objects -->
+  <div class="ml-4" :style="{ color: 'white' }">HelloWorld in the Navbar</div>
+</template>

--- a/src/NestedComponent.vue
+++ b/src/NestedComponent.vue
@@ -16,14 +16,9 @@ import { onMounted, ref } from "vue";
 import { VProgressCircular } from "vuetify/components";
 
 /**
- * Unfortunately Vue doesn't propagate the api type to nested components when using JSDoc
- * type definitions. We can work around this by using the `import()` function to import them.
- * This is optional, but helpfully keeps autocomplete working in the nested component.
- *
  * @typedef {object} Props
  * @property {ReturnType<import("@cloudbolt/js-sdk").createApi>} Props.api - The authenticated API instance
  */
-
 /** @type {Props} */
 const props = defineProps({
   api: {
@@ -70,6 +65,7 @@ async function fetchVersion() {
 onMounted(fetchVersion);
 </script>
 
+<!-- These styles won't affect anything outside this component -->
 <style scoped>
 p {
   font-size: 1.5em;

--- a/src/TheApplet.vue
+++ b/src/TheApplet.vue
@@ -4,42 +4,29 @@
 -->
 <template>
   <!-- 
-    Vue templates have a couple of super-powers over regular HTML. The first used here is `v-if`.
-    This is a conditional that only renders the element if the condition is true.
-    In this case, we're only rendering the "HelloWorld in the Navbar" message if the area includes "Nav".
+    Vue templates have a couple of super-powers over regular HTML.
+    
+    The first here is a custom component NavbarView (imported in <script setup> below). This
+    one is simple, but you can build up complex UIs with nested components with internal states.
+      
+    The second used here is the vue directive `v-if`. This is a conditional that only renders 
+    the element if the condition is true. In this case, we're only rendering the NavbarView 
+    component if the area includes "Nav".
     (we'll get to the `area` prop in the below `script` section)
    -->
-  <div class="ml-4" v-if="area.includes('Nav')">HelloWorld in the Navbar</div>
+  <NavbarView v-if="area.includes('Nav')" />
 
-  <!-- v-else is v-if's counterpart, rendering if the v-if resolves to `false` -->
-  <div v-else>
-    <h2>CB Applet Hello World Example</h2>
-    <p>
-      This is a simple example of a CloudBolt Applet. It's a Vue component that
-      is loaded into the CloudBolt UI and can be used to add functionality to
-      CloudBolt.
+  <!-- 
+    v-else is v-if's counterpart, rendering if the v-if resolves to `false`
+    You can add directives to normal HTML elements too, like this div.
 
-      <!-- 
-        Use double-curly-braces to render a variable from the `script` section in the template. 
-        You can use any valid javascript expression in the double-curly-braces.
-       -->
-      {{ message + "!" }}
-    </p>
-
-    <!-- 
-      If you prepend an attribute with `:` (short for `v-bind:`), vue will treat the attribute's
-      value as javascript. This loads the imageUrl as imported in the below `script` section.
-    -->
-    <img :src="imageUrl" alt="CloudBolt logo" />
-    <p>Time: {{ time }}</p>
-
-    <!-- 
-      One of the other main super-powers of Vue templates is its composability. You can nest
-      components inside of each other to build up complex UIs. This is a nested component that
-      is defined in the `src/NestedComponent.vue` file. It has its own internal state and props.
-      We're passing in the `api` prop from this component to the nested component.
-     -->
-    <NestedComponent :api="api" />
+    This class (ma-3) is a Vuetify utility class that adds some spacing.
+    Vuetify is a great UI library that's included in the CUI.
+    For more information on this class and others: https://vuetifyjs.com/en/styles/spacing/
+  -->
+  <div v-else class="ma-3">
+    <!-- We're binding the api prop to MainVue (see more in the `script` section and in MainView.vue) -->
+    <MainView :api="api" />
   </div>
 </template>
 
@@ -50,31 +37,11 @@
 <script setup>
 /**
  * Import any libraries, assets, and other components you'd like to use.
- * The <script setup> syntax automatically imports defineProps and other define* macros.
+ * The <script setup> syntax automatically imports defineProps and other defineStuff macros.
  * Everything else should be explicitly imported to make sure everything is bundled correctly.
  */
-import camelCase from "camelCase";
-import {
-  computed,
-  defineProps,
-  onBeforeMount,
-  onBeforeUnmount,
-  onBeforeUpdate,
-  onMounted,
-  onUnmounted,
-  onUpdated,
-  ref,
-} from "vue";
-import NestedComponent from "./NestedComponent.vue";
-import imageUrl from "./assets/cb_logo_255x60.png";
-
-/**
- * You can use any third-party library you'd like to install via npm
- * Any libraries you import and use get bundled into the applet.
- */
-const greeting = camelCase("hello-world");
-// Everything defined in <script setup> (like this normal variable) is available in the template above.
-const message = `The string "${greeting}" is processed by an installed npm package`;
+import MainView from "./MainView.vue";
+import NavbarView from "./NavbarView.vue";
 
 /**
  * JSDoc is a great way to document your code and help your IDE provide better autocomplete.
@@ -144,16 +111,17 @@ const props = defineProps({
   /**
    * The page area where the component is being rendered
    * You can use this and `v-if` in the template to render different content in different areas.
+   * In a few cases (like Resource Detail Tab Applets), it's not used at all.
    */
   area: {
     type: String,
-    required: true,
+    default: "",
   },
 
   /**
-   * Individual Applet targets might pass in contextual information that only makes sense for applets in that context.
-   * For example, an applet in a Resource panel may receive the resource id. Console.log(props.context) to see what's
-   * available for your applet.
+   * Individual Applet targets might pass in contextual information that only makes sense for
+   * applets in that context. For example, an applet in a Resource panel may receive the
+   * resource id. console.log(props.context) to see what's available for your applet.
    **/
   context: {
     type: Object,
@@ -163,56 +131,10 @@ const props = defineProps({
 
 /**
  * You can use these props like you'd use regular JS variables.
- * However, they won't be reactive to any changes they receive. We'll get to that next.
+ * However, they won't be reactive to any changes they receive. Read more about that in MainView.vue.
+ * Any code run at this level will only run once when the applet is loaded.
  */
 console.log(
   `This applet is being loaded on the ${props.page} page in the ${props.area} area by ${props.user.username}`
 );
-
-/**
- * The only problem with the above code is that it's not reactive. If I were to change the value of props.page,
- * the console.log wouldn't run again or understand that props.page has changed since the applet first loaded.
- *
- * Vue provides a few ways to make values reactive. The two most common are:
- *  - `ref` - a reactive value that can be changed. https://vuejs.org/guide/essentials/reactivity-fundamentals.html
- *  - `computed` - a reactive value that is derived from other reactive values. https://vuejs.org/guide/essentials/computed.html
- *
- * The vue documentation is excellent and worth reading, but let's explore this with a simple example.
- */
-
-// create a reactive value, initialized to the current date and time
-const currentDateTime = ref(new Date());
-// Create a computed value by defining a function that returns the current time as a string
-const time = computed(() => currentDateTime.value.toLocaleTimeString());
-// We  reference `time` in the template above.
-
-// Let's update the time every second.
-function updateCurrentDateTime() {
-  currentDateTime.value = new Date();
-}
-const timeUpdateInternal = setInterval(updateCurrentDateTime, 1000);
-// As the time changes, the template will update to reflect the new value.
-
-/**
- * Vue also provides lifecycle hooks to run code at different points in the component's lifecycle.
- * These can be used to load data, set up event listeners, clean up, etc.
- * See https://vuejs.org/guide/essentials/lifecycle.html#registering-lifecycle-hooks
- */
-console.log("I run on setup");
-onBeforeMount(() => console.log("I run before the component is mounted"));
-onMounted(() => console.log("I run after the component is mounted"));
-onBeforeUpdate(() => console.log("I run before the component is updated"));
-onUpdated(() => console.log("I run after the component is updated"));
-onBeforeUnmount(() => console.log("I run before the component is unmounted"));
-onUnmounted(() => console.log("I run after the component is unmounted"));
-
-// Let's use one of these to clean up the interval we created earlier when we unmount the component.
-onUnmounted(() => clearInterval(timeUpdateInternal));
 </script>
-
-<!-- The `style` is where you write your CSS. "scoped" styles only apply to this component. -->
-<style scoped>
-h2 {
-  color: #1e88e5;
-}
-</style>


### PR DESCRIPTION
Add example configuration for a Resource Detail Applet Tab.
Decompose the example a bit, adding more docs along the way.