### PR TITLE
[ENG-25279] Inbound Webhook example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "vuetify": "^3.1.13"
       },
       "devDependencies": {
-        "@cloudbolt/js-sdk": "^0.6.0",
+        "@cloudbolt/js-sdk": "^0.6.2",
         "@cloudbolt/xui-packager": "^1.1.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@vitejs/plugin-vue": "^4.2.3",
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@cloudbolt/js-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@cloudbolt/js-sdk/-/js-sdk-0.6.0.tgz",
-      "integrity": "sha512-XVzT+JCG2vIouzsy2Y07Cv2SHIMNJxfVF9KWhvOEn0o1lk3l2dPxCyDsaEEucVkuG8jCpOVbqq++dnDBVJG5NA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@cloudbolt/js-sdk/-/js-sdk-0.6.2.tgz",
+      "integrity": "sha512-MWysv3az1kb211Ata3TjpVS/nyzyUnksnZk+4XOOIjMLmdtCFKIV9G1DmnWuUmhPBgEacHJiH58KvVEqyKbuXw==",
       "dev": true,
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "vuetify": "^3.1.13"
   },
   "devDependencies": {
-    "@cloudbolt/js-sdk": "^0.6.0",
+    "@cloudbolt/js-sdk": "^0.6.2",
     "@cloudbolt/xui-packager": "^1.1.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@vitejs/plugin-vue": "^4.2.3",

--- a/src/MainView.vue
+++ b/src/MainView.vue
@@ -1,4 +1,9 @@
 <template>
+  <!-- 
+    If you prepend an attribute with `:` (short for `v-bind:`), vue will treat the attribute's
+    value as javascript. This loads the imageUrl as imported in the below `script` section.
+  -->
+  <img :src="imageUrl" alt="CloudBolt logo" />
   <h2>CB Applet Hello World Example</h2>
   <p>
     This is a simple example of a CloudBolt Applet. It's a Vue component that is
@@ -6,23 +11,18 @@
     CloudBolt.
 
     <!-- 
-        Use double-curly-braces to render a variable from the `script` section in the template. 
-        You can use any valid javascript expression in the double-curly-braces.
-       -->
+      Use double-curly-braces to render a variable from the `script` section in the template. 
+      You can use any valid javascript expression in the double-curly-braces.
+      -->
     {{ message + "!" }}
   </p>
-
-  <!-- 
-      If you prepend an attribute with `:` (short for `v-bind:`), vue will treat the attribute's
-      value as javascript. This loads the imageUrl as imported in the below `script` section.
-    -->
-  <img :src="imageUrl" alt="CloudBolt logo" />
   <p>Time: {{ time }}</p>
 
   <!-- 
-      Prepend props like "api" with `:` to bind them to child components. `:` is short for `v-bind:`.
-     -->
+    Prepend props like "api" with `:` to bind them to child components. `:` is short for `v-bind:`.
+    -->
   <NestedComponent :api="api" />
+  <NestedExamples :api="api" />
   <ACounter />
 </template>
 
@@ -41,6 +41,7 @@ ref,
 } from "vue";
 import ACounter from "./ACounter.vue";
 import NestedComponent from "./NestedComponent.vue";
+import NestedExamples from "./NestedExamples.vue";
 import imageUrl from "./assets/cb_logo_255x60.png";
 
 /**

--- a/src/MainView.vue
+++ b/src/MainView.vue
@@ -29,15 +29,15 @@
 <script setup>
 import camelCase from "camelCase";
 import {
-  computed,
-  defineProps,
-  onBeforeMount,
-  onBeforeUnmount,
-  onBeforeUpdate,
-  onMounted,
-  onUnmounted,
-  onUpdated,
-  ref,
+computed,
+defineProps,
+onBeforeMount,
+onBeforeUnmount,
+onBeforeUpdate,
+onMounted,
+onUnmounted,
+onUpdated,
+ref,
 } from "vue";
 import NestedComponent from "./NestedComponent.vue";
 import imageUrl from "./assets/cb_logo_255x60.png";

--- a/src/NestedComponent.vue
+++ b/src/NestedComponent.vue
@@ -60,9 +60,31 @@ async function fetchVersion() {
     console.error(error);
   }
 }
+async function fetchInboundWebHook() {
+  try {
+    // Use the ID provided by the URL of your webhook.
+    // This value must be  
+    // Ex. /api/v3/cmp/inboundWebHooks/IWH-f7gfst8e/run/
+    const webHookId = 'IWH-f7gfst8e'
+    // Optional Parameters Object 
+    const options = {value: 'Your parameters'}
+    // Another Async call to the api
+    // Use `.then()` and `.catch()` to handle the response
+    // https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises
+    const webHook = await props.api.v3.cmp.inboundWebHooks.runGet(webHookId, options)
+    // Logging the response for this example
+    console.log(webHook)
+  } catch (error) {
+    // When using API calls, it's a good idea to catch errors and meaningfully display them.
+    // In this case, we'll just log the error to the console.
+    console.error(error);
+  }
+}
 
 // Run the function when the component is mounted.
 onMounted(fetchVersion);
+// Uncomment to run this command once you provide the ID
+onMounted(fetchInboundWebHook)
 </script>
 
 <!-- These styles won't affect anything outside this component -->

--- a/src/NestedComponent.vue
+++ b/src/NestedComponent.vue
@@ -60,31 +60,9 @@ async function fetchVersion() {
     console.error(error);
   }
 }
-async function fetchInboundWebHook() {
-  try {
-    // Use the ID provided by the URL of your webhook.
-    // This value must be  
-    // Ex. /api/v3/cmp/inboundWebHooks/IWH-f7gfst8e/run/
-    const webHookId = 'IWH-f7gfst8e'
-    // Optional Parameters Object 
-    const options = {value: 'Your parameters'}
-    // Another Async call to the api
-    // Use `.then()` and `.catch()` to handle the response
-    // https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises
-    const webHook = await props.api.v3.cmp.inboundWebHooks.runGet(webHookId, options)
-    // Logging the response for this example
-    console.log(webHook)
-  } catch (error) {
-    // When using API calls, it's a good idea to catch errors and meaningfully display them.
-    // In this case, we'll just log the error to the console.
-    console.error(error);
-  }
-}
 
 // Run the function when the component is mounted.
 onMounted(fetchVersion);
-// Uncomment to run this command once you provide the ID
-onMounted(fetchInboundWebHook)
 </script>
 
 <!-- These styles won't affect anything outside this component -->

--- a/src/NestedExamples.vue
+++ b/src/NestedExamples.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- 
     VCard comes from Vuetify: https://vuetifyjs.com/en/components/cards/
-    and provide a great way to wrap content together
+    and provide a great way to wrap related content together
     max-width and the margin class "mb-2" provide simple css customization
   -->
   <VCard
@@ -22,10 +22,7 @@
 
 <script setup>
 /**
- * Vuetify has a rich ecosystem of pre-built components that you can use in your applets.
- * We use them throughout the CloudBolt UI, so they'll help your applet fit in.
- * This one in particular is a simple loading spinner.
- * https://vuetifyjs.com/en/components/progress-circular/
+ * Here we are using our custom SimpleButton in multiple iterations
  */
 import { ref } from "vue";
 import SimpleButton from "./SimpleButton.vue";

--- a/src/NestedExamples.vue
+++ b/src/NestedExamples.vue
@@ -1,0 +1,80 @@
+<template>
+    <!-- 
+    VCard comes from Vuetify: https://vuetifyjs.com/en/components/cards/
+    and provide a great way to wrap content together
+    max-width and the margin class "mb-2" provide simple css customization
+  -->
+  <VCard
+    :loading="apiResponseLoading"
+    title="API Examples"
+    max-width="25%"
+    class="mb-2">
+    <VCardActions>
+      <!-- API Example for Inbound Webhooks -->
+      <SimpleButton 
+        text="Fetch Inbound Webhook" 
+        disabled-text="Update Webhook ID to enable" 
+        :button-action="fetchInboundWebHook" 
+        :disabled="!Boolean(webHookId)"/>
+    </VCardActions>
+  </VCard>
+</template>
+
+<script setup>
+/**
+ * Vuetify has a rich ecosystem of pre-built components that you can use in your applets.
+ * We use them throughout the CloudBolt UI, so they'll help your applet fit in.
+ * This one in particular is a simple loading spinner.
+ * https://vuetifyjs.com/en/components/progress-circular/
+ */
+import { ref } from "vue";
+import SimpleButton from "./SimpleButton.vue";
+
+/**
+ * @typedef {object} Props
+ * @property {ReturnType<import("@cloudbolt/js-sdk").createApi>} Props.api - The authenticated API instance
+ */
+/** @type {Props} */
+const props = defineProps({
+  api: {
+    type: Object,
+    required: true,
+  },
+});
+
+/**
+ * Similar to the first NestedComponent, we'll use the `api` prop to make a variety of API calls.
+ * We'll also reactively store the loading state while each call is fetching. 
+ * Each call will be handled separately and triggered by their individual buttons.
+ */
+const apiResponseLoading = ref(false);
+
+// Use the ID provided by the URL of your webhook.
+// Ex. /api/v3/cmp/inboundWebHooks/IWH-f7gfst8e/run/ results in webHookId = 'IWH-f7gfst8e'
+// Using the ref allows disabling the SimpleButton component when value is not set
+const webHookId = ''
+async function fetchInboundWebHook() {
+  try {
+    // Webhook ID must be correctly set for this function to work.
+    // Optional Parameters Object 
+    const options = {value: 'Your parameters'}
+    apiResponseLoading.value = true;
+    // Another Async call to the api
+    // Use `.then()` and `.catch()` to handle the response
+    // https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises
+    const webHook = await props.api.v3.cmp.inboundWebHooks.runGet(webHookId, options)
+    // Logging the response for this example
+    console.log(webHook)
+    apiResponseLoading.value = false;
+  } catch (error) {
+    // When using API calls, it's a good idea to catch errors and meaningfully display them.
+    // In this case, we'll just log the error to the console.
+    console.error(error);
+  }
+}
+
+</script>
+
+<!-- These styles won't affect anything outside this component -->
+<style scoped>
+</style>

--- a/src/SimpleButton.vue
+++ b/src/SimpleButton.vue
@@ -1,0 +1,42 @@
+<template>
+  <!-- 
+    VBtn comes from Vuetify: https://vuetifyjs.com/en/components/buttons/ 
+  
+    The `@click`s are a examples of how you bind js functions to events on elements.
+    See more: https://vuejs.org/guide/essentials/event-handling.html
+  -->
+  <VBtn :disabled="disabled" :text="buttonText" @click="buttonAction" class="d-block my-1" variant="outlined"></VBtn>
+</template>
+
+<script setup>
+import { computed } from "vue";
+/**
+ * @typedef {object} Props
+ * @property {function} Props.buttonAction - Function to run when button clicked
+ * @property {string} Props.text - String for button text
+ * @property {string} Props.disabledText - String for button text when disabled
+ * @property {boolean} Props.disabled - Boolean to toggle button functionality
+ */
+/** @type {Props} */
+const props = defineProps({
+  text: {
+    type: String,
+    required: true
+  },
+  buttonAction: {
+    type: Function,
+    required: true
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  disabledText: {
+    type: String,
+    default: ''
+  }
+});
+
+const buttonText = computed(()=> props.disabled && props.disabledText ? props.disabledText : props.text)
+
+</script>


### PR DESCRIPTION
[Ticket ENG-25279](https://cloudbolt.atlassian.net/browse/ENG-25279)

Adds a simple example of an inbound webhook call
Because the nature of this call is that it won't work as an example unless the user already has a webhook setup and requires a custom ID, added a button I plan to reuse to control the request and indicate to the user the presence of the functionality

Default state 
![Screenshot 2023-07-17 at 1 57 04 PM](https://github.com/CloudBoltSoftware/cb-applet/assets/105660893/34c6db9b-0b97-4586-bfbb-9460c5e75f05)

User updates webhook ID
![Screenshot 2023-07-17 at 1 56 21 PM](https://github.com/CloudBoltSoftware/cb-applet/assets/105660893/6dc58d9a-111b-4b2c-aa90-64c092e591dc)
