### PR TITLE
ENG-25433 added applet to more widgets and table

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     ],
     "met_targets": {
       "cui": {
+        "resourcesDetailsPaneDiskList": ["preTable", "postTable", "expandedCellFoot"],
+        "resourcesDetailsPaneNetworks": ["preTable", "postTable", "expandedCellHead"],
+        "resourceDetailsDiskList": ["preTable", "postTable", "expandedCellFoot"],
+        "resourceDetailsNetworks": ["preTable", "postTable", "expandedCellHead"],
         "resourceDetailsTabs": [
           {
             "resourceTypes": [


### PR DESCRIPTION
[Ticket - ENG-25433](https://cloudbolt.atlassian.net/browse/ENG-25433)
Engineer - @tropotorres 

Added to the `pre` and `post` tables on Networks
![Screenshot 2023-07-27 at 12 26 18 PM](https://github.com/CloudBoltSoftware/cb-applet/assets/105660893/33de5e6c-667d-4d68-a26a-18d4497e4306)

Added to the expanded cell content in the Network table
ALSO in this location the context being passed is the `item` data from the table entry
![Screenshot 2023-07-27 at 12 26 12 PM](https://github.com/CloudBoltSoftware/cb-applet/assets/105660893/0c8acb37-579d-479b-b5b0-b90fb20f23ab)
